### PR TITLE
Review nov19

### DIFF
--- a/subspace_model/logic.py
+++ b/subspace_model/logic.py
@@ -137,14 +137,13 @@ def p_archive(params: SubspaceModelParams, _2, _3, state: SubspaceModelState) ->
     TODO: revisit assumption on the supply & demand matching.
     FIXME: homogenize terminology
     """
-    realized_depth = state['delta_blocks']
-    segments_supply = realized_depth / params['archival_depth']
+    #how much data does every block contain aside from tx data
+    header_volume = state['delta_blocks'] * params['header_size']
     
     tx_volume = state['transaction_count'] * state['average_transaction_size']
-    new_buffer_bytes = tx_volume
+    new_buffer_bytes = tx_volume + header_volume
     current_buffer = new_buffer_bytes + state['buffer_size']
-    segments_demand = current_buffer / params['archival_buffer_segment_size']
-    segments_being_archived = floor(int(min(segments_supply, segments_demand)))
+    segments_being_archived = int(floor(current_buffer / params['archival_buffer_segment_size']))
 
     new_history_bytes = 0
     if segments_being_archived > 0:

--- a/subspace_model/params.py
+++ b/subspace_model/params.py
@@ -106,8 +106,8 @@ SINGLE_RUN_PARAMS = SubspaceModelParams(
     transfer_holder_to_operator_per_day=0.01, # TODO
 
     # Environmental Parameters
-    avg_base_fee=5,
-    std_base_fee=15,
+    avg_base_fee=1,
+    std_base_fee=1,
     min_base_fee=1,
 
     avg_priority_fee=3,

--- a/subspace_model/params.py
+++ b/subspace_model/params.py
@@ -77,6 +77,7 @@ SINGLE_RUN_PARAMS = SubspaceModelParams(
     block_time_in_seconds=BLOCK_TIME,
     archival_depth=ARCHIVAL_DEPTH,
     archival_buffer_segment_size=SEGMENT_SIZE,
+    header_size=6_500, #how much data does every block contain on top of txs: signature, solution, consensus logs, etc. + votes + PoT
     replication_factor=10,
     max_block_size=int(3.75 * MIB_IN_BYTES), # 3.75 MiB
 
@@ -112,14 +113,25 @@ SINGLE_RUN_PARAMS = SubspaceModelParams(
     avg_priority_fee=3,
     std_priority_fee=5,
 
-    avg_compute_weights_per_tx=200, # TODO
-    std_compute_weights_per_tx=500, # TODO
-    min_compute_weights_per_tx=10, # TODO
+    avg_compute_weights_per_tx=60_000_000, # TODO
+    std_compute_weights_per_tx=15_000_000, # TODO
+    min_compute_weights_per_tx=6_000_000, # TODO
 
-    avg_transaction_size=600_000, # TODO
-    std_transaction_size=100_000, # TODO
+    #bundles are usually compute heavy
+    avg_compute_weights_per_bundle=10_000_000_000, # TODO
+    std_compute_weights_per_bundle=5_000_000_000, # TODO
+    min_compute_weights_per_bundle=2_000_000_000, # TODO
+
+    avg_transaction_size=256, # TODO
+    std_transaction_size=100, # TODO
     min_transaction_size=100, # TODO
+
+    avg_bundle_size=1500, # TODO
+    std_bundle_size=1000, # TODO
+    min_bundle_size=250, # TODO
+
     avg_transaction_count_per_day=1 * (24*60*60/BLOCK_TIME), # XXX: X tx per block
+    avg_bundle_count_per_day= 6 * (24*60*60/BLOCK_TIME), # 6 bundles per block, 1 every second
 
     avg_slash_per_day=0.1, # TODO
     avg_new_sectors_per_day=1_000, # TODO

--- a/subspace_model/types.py
+++ b/subspace_model/types.py
@@ -100,6 +100,7 @@ class SubspaceModelParams(TypedDict):
     block_time_in_seconds: Seconds
     archival_depth: Blocks
     archival_buffer_segment_size: Bytes
+    header_size: Bytes
     replication_factor: float
     max_block_size: Bytes
 


### PR DESCRIPTION
This PR is not meant to be merged. 
Suggesting a few corrections to the model:
- remove archived segment supply side per discussion on Nov 17
- added a parameter `header_size` for size of auxiliary data present in each block for archiving: header, votes, proof-of-time
- updated average transaction size and weight to realistic values
- added average bundle size and weight to realistic values. I did not, however, count them into archiving or fees or state variables yet, so the current state wouldn't compile correctly 
- corrected priority fee to be counted once per transaction
- updated "base_fee" to 1. IIUC, you multiply it by weight, so it would correspond to what we call "`weight_to_fee`," and it is currently set to 1 Shannon per weight unit in the protocol, which is an inadequate value that we hope this model will help parameterize correctly. I suggest you rename it to `weight_to_fee` and change the type of this to be in Shannons rather than credits

I didn't make super invasive changes (i.e. introducing bundles everywhere), wanted to bring to your attention first. 